### PR TITLE
Interface support

### DIFF
--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -211,21 +211,14 @@ function addResolveFunctionsToSchema(schema, resolveFunctions) {
       );
     }
 
-    // treat isTypeOf and resolveType differently
-    // TODO require resolveType for unions and interfaces.
-    // XXX this is getting messier and messier. Will need refactoring soon
-    if (resolveFunctions[typeName].isTypeOf) {
-      console.log('is type of!');
-      type.isTypeOf = resolveFunctions[typeName].isTypeOf;
-    }
-    if (resolveFunctions[typeName].resolveType) {
-      type.resolveType = resolveFunctions[typeName].resolveType;
-    }
-
     Object.keys(resolveFunctions[typeName]).forEach((fieldName) => {
-      if (fieldName === 'isTypeOf' || fieldName === 'resolveType') {
+      if (fieldName.startsWith('__')) {
+        // this is for isTypeOf and resolveType and all the other stuff.
+        // TODO require resolveType for unions and interfaces.
+        type[fieldName.substring(2)] = resolveFunctions[typeName][fieldName];
         return;
       }
+
       if (!type.getFields()[fieldName]) {
         throw new SchemaError(
           `${typeName}.${fieldName} defined in resolvers, but not in schema`

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -211,7 +211,21 @@ function addResolveFunctionsToSchema(schema, resolveFunctions) {
       );
     }
 
+    // treat isTypeOf and resolveType differently
+    // TODO require resolveType for unions and interfaces.
+    // XXX this is getting messier and messier. Will need refactoring soon
+    if (resolveFunctions[typeName].isTypeOf) {
+      console.log('is type of!');
+      type.isTypeOf = resolveFunctions[typeName].isTypeOf;
+    }
+    if (resolveFunctions[typeName].resolveType) {
+      type.resolveType = resolveFunctions[typeName].resolveType;
+    }
+
     Object.keys(resolveFunctions[typeName]).forEach((fieldName) => {
+      if (fieldName === 'isTypeOf' || fieldName === 'resolveType') {
+        return;
+      }
       if (!type.getFields()[fieldName]) {
         throw new SchemaError(
           `${typeName}.${fieldName} defined in resolvers, but not in schema`

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -218,8 +218,24 @@ function addResolveFunctionsToSchema(schema, resolveFunctions) {
         );
       }
       const field = type.getFields()[fieldName];
-      field.resolve = resolveFunctions[typeName][fieldName];
+      const fieldResolve = resolveFunctions[typeName][fieldName];
+      if (typeof fieldResolve === 'function') {
+        // for convenience. Allows shorter syntax in resolver definition file
+        setFieldProperties(field, { resolve: fieldResolve });
+      } else {
+        if (typeof fieldResolve !== 'object') {
+          throw new SchemaError(`Resolver ${typeName}.${fieldName} must be object or function`);
+        }
+        setFieldProperties(field, fieldResolve);
+      }
     });
+  });
+}
+
+function setFieldProperties(field, propertiesObj) {
+  Object.keys(propertiesObj).forEach((propertyName) => {
+    // eslint-disable-next-line no-param-reassign
+    field[propertyName] = propertiesObj[propertyName];
   });
 }
 

--- a/test/testSchemaGenerator.js
+++ b/test/testSchemaGenerator.js
@@ -309,8 +309,6 @@ describe('generating schema from shorthand', () => {
       }
       type RootQuery {
         search(name: String): [Searchable]
-        a: Location
-        b: Person
       }
       schema {
         query: RootQuery
@@ -319,8 +317,6 @@ describe('generating schema from shorthand', () => {
 
     const resolveFunctions = {
       RootQuery: {
-        a: () => null,
-        b: () => null,
         search: {
           resolve(root, { name }) {
             return [{

--- a/test/testSchemaGenerator.js
+++ b/test/testSchemaGenerator.js
@@ -330,7 +330,7 @@ describe('generating schema from shorthand', () => {
         },
       },
       Searchable: {
-        resolveType(data, context, info) {
+        __resolveType(data, context, info) {
           if (data.age) {
             return info.schema.getType('Person');
           }


### PR DESCRIPTION
This adds support for interfaces, union types and scalars via the addResolveFunctionsToSchema. That function should probably be renamed to something like addExecutionInfoToSchema, because it's no longer just resolve functions.