### PR TITLE
Mock unions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tools",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A set of useful GraphQL tools",
   "main": "dist/index.js",
   "directories": {

--- a/src/mock.js
+++ b/src/mock.js
@@ -2,6 +2,7 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLEnumType,
+  GraphQLUnionType,
   GraphQLList,
   getNullableType,
   getNamedType,
@@ -120,6 +121,13 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
       if (fieldType instanceof GraphQLObjectType) {
         // objects don't return actual data, we only need to mock scalars!
         return {};
+      }
+      // TODO mocking Interface and Union types will require determining the
+      // resolve type before passing it on.
+      // XXX we recommend a generic way for resolve type here, which is defining
+      // typename on the object.
+      if (fieldType instanceof GraphQLUnionType) {
+        return { typename: casual.random_element(fieldType.getTypes()) };
       }
       if (fieldType instanceof GraphQLEnumType) {
         return casual.random_element(fieldType.getValues()).value;

--- a/src/mock.js
+++ b/src/mock.js
@@ -127,6 +127,8 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
       // XXX we recommend a generic way for resolve type here, which is defining
       // typename on the object.
       if (fieldType instanceof GraphQLUnionType) {
+        // TODO: if a union type doesn't implement resolveType, we could overwrite
+        // it with a default that works with what's below.
         return { typename: casual.random_element(fieldType.getTypes()) };
       }
       if (fieldType instanceof GraphQLEnumType) {


### PR DESCRIPTION
This solves #34 partly by returning a random implementing type. The mock function hints at what type is returned by setting typename on the object. Unions must thus have a resolveType method that looks like this in order to work (this is something I recommend doing anyway, in order to avoid fuzzy type logic which could be hard to debug).
```js
resolveType(data, context, info){
  return info.schema.getType(data.typename);
}
```

For interfaces it's a bit trickier, because they don't know what types implement them. It should however be possible to simply check all types in the schema to see if they implement the interface. 