### PR TITLE
pass context to connector constructor

### DIFF
--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -177,7 +177,7 @@ function attachConnectorsToContext(schema, connectors) {
     }
     Object.keys(connectors).forEach((connectorName) => {
       // eslint-disable-next-line no-param-reassign
-      ctx.connectors[connectorName] = new connectors[connectorName]();
+      ctx.connectors[connectorName] = new connectors[connectorName](ctx);
     });
     return root;
   };


### PR DESCRIPTION
Does what it says. This is useful for taking tokens etc from the context during the construction of a connector.