### PR TITLE
Adding `allowDefaultResolve` option to `makeExecutableSchema` to allo…

### DIFF
--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -34,8 +34,11 @@ function _generateSchema(
   logger,
   // TODO: rename to allowUndefinedInResolve to be consistent
   allowUndefinedInResolve = true,
-  allowDefaultResolve = false,
+  resolverValidationOptions = {},
 ) {
+  if (typeof resolverValidationOptions !== 'object') {
+    throw new SchemaError('Expected `resolverValidationOptions` to be an object');
+  }
   if (!typeDefinitions) {
     throw new SchemaError('Must provide typeDefinitions');
   }
@@ -49,7 +52,7 @@ function _generateSchema(
 
   addResolveFunctionsToSchema(schema, resolveFunctions);
 
-  assertResolveFunctionsPresent(schema, allowDefaultResolve);
+  assertResolveFunctionsPresent(schema, resolverValidationOptions);
 
   if (!allowUndefinedInResolve) {
     addCatchUndefinedToSchema(schema);
@@ -68,9 +71,9 @@ function makeExecutableSchema({
   connectors,
   logger,
   allowUndefinedInResolve = false,
-  allowDefaultResolve = false,
+  resolverValidationOptions = {},
 }) {
-  const jsSchema = _generateSchema(typeDefs, resolvers, logger, allowUndefinedInResolve, allowDefaultResolve);
+  const jsSchema = _generateSchema(typeDefs, resolvers, logger, allowUndefinedInResolve, resolverValidationOptions);
   if (typeof resolvers.__schema === 'function') {
     // TODO a bit of a hack now, better rewrite generateSchema to attach it there.
     // not doing that now, because I'd have to rewrite a lot of tests.
@@ -250,15 +253,20 @@ function setFieldProperties(field, propertiesObj) {
   });
 }
 
-function assertResolveFunctionsPresent(schema, allowNonScalar) {
+function assertResolveFunctionsPresent(schema, resolverValidationOptions = {}) {
+  const {
+    requireResolversForArgs = true,
+    requireResolversForNonScalar = true,
+  } = resolverValidationOptions;
+
   forEachField(schema, (field, typeName, fieldName) => {
     // requires a resolve function on every field that has arguments
-    if (field.args.length > 0) {
+    if (requireResolversForArgs && field.args.length > 0) {
       expectResolveFunction(field, typeName, fieldName);
     }
 
     // requires a resolve function on every field that returns a non-scalar type
-    if (!allowNonScalar && !(getNamedType(field.type) instanceof GraphQLScalarType)) {
+    if (requireResolversForNonScalar && !(getNamedType(field.type) instanceof GraphQLScalarType)) {
       expectResolveFunction(field, typeName, fieldName);
     }
   });

--- a/test/testSchemaGenerator.js
+++ b/test/testSchemaGenerator.js
@@ -516,6 +516,23 @@ describe('generating schema from shorthand', () => {
     assert.throws(generateSchema.bind(null, short, rf), SchemaError);
   });
 
+  it('allows non-scalar field to use default resolve func if "allowDefaultResolve" == true', () => {
+    const short = `
+    type Bird{
+      id: ID
+    }
+    type Query{
+      bird: Bird
+    }
+    schema {
+      query: Query
+    }`;
+
+    const rf = {};
+
+    assert.doesNotThrow(makeExecutableSchema.bind(null, { typeDefs: short, resolvers: rf, allowDefaultResolve: true }), SchemaError);
+  });
+
   it('throws an error if a resolve field cannot be used', (done) => {
     const shorthand = `
       type BirdSpecies {

--- a/test/testSchemaGenerator.js
+++ b/test/testSchemaGenerator.js
@@ -468,6 +468,20 @@ describe('generating schema from shorthand', () => {
     assert.throws(generateSchema.bind(null, short, rf), SchemaError);
   });
 
+  it('does not throw an error if `resolverValidationOptions.requireResolversForArgs` is false', () => {
+    const short = `
+    type Query{
+      bird(id: ID): String
+    }
+    schema {
+      query: Query
+    }`;
+
+    const rf = { Query: {} };
+
+    assert.doesNotThrow(makeExecutableSchema.bind(null, { typeDefs: short, resolvers: rf, resolverValidationOptions: { requireResolversForArgs: false } }), SchemaError);
+  });
+
   it('throws an error if field.resolve is not a function', () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -516,7 +530,7 @@ describe('generating schema from shorthand', () => {
     assert.throws(generateSchema.bind(null, short, rf), SchemaError);
   });
 
-  it('allows non-scalar field to use default resolve func if "allowDefaultResolve" == true', () => {
+  it('allows non-scalar field to use default resolve func if `resolverValidationOptions.requireResolversForNonScalar` = false', () => {
     const short = `
     type Bird{
       id: ID
@@ -530,7 +544,7 @@ describe('generating schema from shorthand', () => {
 
     const rf = {};
 
-    assert.doesNotThrow(makeExecutableSchema.bind(null, { typeDefs: short, resolvers: rf, allowDefaultResolve: true }), SchemaError);
+    assert.doesNotThrow(makeExecutableSchema.bind(null, { typeDefs: short, resolvers: rf, resolverValidationOptions: { requireResolversForNonScalar: false } }), SchemaError);
   });
 
   it('throws an error if a resolve field cannot be used', (done) => {


### PR DESCRIPTION
Adding `allowDefaultResolve` option to `makeExecutableSchema` to allow non-scalar types to use the GraphQL default resolve function. 

Issue: #44 