### PR TITLE
Issue 60/resolvers and mocking

### DIFF
--- a/src/apolloServer.js
+++ b/src/apolloServer.js
@@ -3,6 +3,7 @@ import {
   buildSchemaFromTypeDefinitions,
   addErrorLoggingToSchema,
   addCatchUndefinedToSchema,
+  addResolveFunctionsToSchema,
   addTracingToResolvers,
 } from './schemaGenerator';
 import { addMockFunctionsToSchema } from './mock';
@@ -79,6 +80,7 @@ export default function apolloServer(options, ...rest) {
         // have to rewrite these functions
         const myMocks = mocks || {};
         executableSchema = buildSchemaFromTypeDefinitions(schema);
+        addResolveFunctionsToSchema(executableSchema, resolvers || {});
         addMockFunctionsToSchema({
           schema: executableSchema,
           mocks: myMocks,


### PR DESCRIPTION
These patches allow to specify both resolvers and mocks options in a call to apolloServer. It is motivated by the need to define a resolveType function for mocking union types.

Related issues:
#60 
https://github.com/apollostack/apollo-starter-kit/issues/9