### PR TITLE
reduce package size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
 install:
   - npm install -g coveralls
   - npm install
-  - npm install # npm bug. installing twice ensures we have all deps
 
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 install:
   - npm install -g coveralls
   - npm install
+  - npm install # npm bug. installing twice ensures we have all deps
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "fs": "0.0.2",
     "graphql": "^0.6.0",
     "istanbul": "1.0.0-alpha.2",
+    "lodash": "^4.10.0",
     "mocha": "^2.3.3",
     "multer": "^1.0.3",
     "nodemon": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,8 @@
   },
   "homepage": "https://github.com/apollostack/apollo-proxy#readme",
   "dependencies": {
-    "babel-polyfill": "^6.5.0",
-    "fs": "0.0.2",
-    "lodash": "^4.10.0",
-    "node-uuid": "^1.4.7",
-    "performance-now": "^0.2.0",
-    "request": "^2.72.0"
+    "lodash.uniq": "^4.3.0",
+    "node-uuid": "^1.4.7"
   },
   "peerDependencies": {
     "graphql": "^0.5.0 || ^0.6.0"
@@ -46,6 +42,7 @@
     "babel-core": "6.9.1",
     "babel-eslint": "^6.0.0-beta.6",
     "babel-loader": "6.2.4",
+    "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "body-parser": "^1.15.0",
@@ -58,11 +55,13 @@
     "eslint-plugin-react": "^5.1.1",
     "express": "^4.13.4",
     "express3": "0.0.0",
+    "fs": "0.0.2",
     "graphql": "^0.6.0",
     "istanbul": "1.0.0-alpha.2",
     "mocha": "^2.3.3",
     "multer": "^1.0.3",
     "nodemon": "^1.9.1",
+    "request": "^2.72.0",
     "request-promise": "^3.0.0",
     "supertest": "^1.0.1",
     "supertest-as-promised": "^3.1.0",

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -4,7 +4,7 @@
 // and what it outputs.
 
 import { parse } from 'graphql/language';
-import { uniq } from 'lodash';
+import uniq from 'lodash.uniq';
 import { buildASTSchema } from 'graphql/utilities';
 import {
   GraphQLScalarType,


### PR DESCRIPTION
Firstly thanks for this great library!

I noticed that alot of the dependencies in package.json could be moved to devDependencies since they are only referenced from test files. I also changed lodash to lodash.uniq since this is the only function used. This makes a fair bit of difference on the install size of the production version of node_modules 7MB down to 100 KB. 

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x]  Rebase your changes on master so that they can be merged easily
- [x]  Make sure all tests and linter rules pass