### PR TITLE
Added `extend` support to schemaGenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v0.6.2
+### vNEXT
 * Added support for `extend` keyword to schemaGenerator https://github.com/apollostack/graphql-tools/pull/90
 
 ### v0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### v0.6.2
+* Added support for `extend` keyword to schemaGenerator https://github.com/apollostack/graphql-tools/pull/90
+
 ### v0.5.2
 
 * Add addSchemaLevelResolveFunction to exports

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -134,10 +134,6 @@ function buildSchemaFromTypeDefinitions(typeDefinitions) {
 }
 
 function extractExtensionDefinitions(ast) {
-  if (!ast || ast.kind !== Kind.DOCUMENT) {
-    return [];
-  }
-
   const extensionDefs =
     ast.definitions.filter((def) => def.kind === Kind.TYPE_EXTENSION_DEFINITION);
 


### PR DESCRIPTION
This PR is meant to allow use of the following IDL syntax:
https://github.com/graphql/graphql-js/blob/9ea8196c2af97551bab5cfd57201c29e3085ee4e/src/utilities/__tests__/extendSchema.js#L127

It seems to a feature that was meant to be used for client purposes only.
But, in my opinion, while using the IDL to describe type definitions, you lose to ability to do cyclic dependencies and by that, the ability to create suite packages that will enhance and be enhanced by your own application code base.

e.g: 

Consider the [accounts package](https://github.com/davidyaha/apollo-accounts-server/blob/master/server/imports/api/schema.js) as the sole owner of the User type, being so, in your own schema files, you would like to use that same User type to describe relations to other types. 
Lets say Post
```
type Post {
  id: ID!
  creator: User
}
``` 
And so you would also like to expand on the User type to allow for relations to the Post type:
```
extend type User {
  posts: [Post]
}
```

Other possible solutions could be to use union types but these will not allow to get the extended User type on the queries provided by the accounts package

This PR is not harming any previous features of the schemaGenerator. 
One current limitation is that after you've added an `extend` type definition, you have to provide type resolvers for all fields.

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

