### PR TITLE
WIP: test to show that mocking & resolving cannot be used concurrentl…

### DIFF
--- a/src/mock.js
+++ b/src/mock.js
@@ -156,10 +156,6 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
   };
 
   forEachField(schema, (field, typeName, fieldName) => {
-    if (preserveResolvers && field.resolve) {
-      return;
-    }
-
     // we have to handle the root mutation and root query types differently,
     // because no resolver is called at the root.
     const isOnQueryType = typeName === (schema.getQueryType() || {}).name;
@@ -185,8 +181,20 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
         }
       }
     }
-    // eslint-disable-next-line no-param-reassign
-    field.resolve = mockType(field.type, typeName, fieldName);
+    if (!preserveResolvers || !field.resolve) {
+      // eslint-disable-next-line no-param-reassign
+      field.resolve = mockType(field.type, typeName, fieldName);
+    } else {
+      const oldResolver = field.resolve;
+      const mockResolver = mockType(field.type, typeName, fieldName);
+      // eslint-disable-next-line no-param-reassign
+      field.resolve = (...args) => {
+        const mockedValue = mockResolver(...args);
+        const resolvedValue = oldResolver(...args);
+        return typeof mockedValue === 'object' && typeof resolvedValue === 'object'
+          ? Object.assign({}, mockedValue, resolvedValue) : resolvedValue;
+      };
+    }
   });
 }
 


### PR DESCRIPTION
Per @helfer suggestion in apollostack/apollo-server#9, submit a PR with **a failing test**, showing a case where mocks and resolver can't be use concurrently. 
Thank you.