### PR TITLE
Add `requireResolversForAllFields` resolver validation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### vNEXT
 * Make allowUndefinedInResolve true by default ([@jbaxleyiii](https://github.com/jbaxleyiii) in [#117]((https://github.com/apollostack/graphql-tools/pull/117))
 
+* Add `requireResolversForAllFields` resolver validation option ([@nevir](https://github.com/nevir) in [#107](https://github.com/apollostack/graphql-tools/pull/107))
+
 ### v0.6.4
 * Make mocking partial objects match expected behavior ([@sebastienbarre](https://github.com/sebastienbarre) in [#96](https://github.com/apollostack/graphql-tools/pull/96))
 * Improved behavior when mocking interfaces & unions ([@itajaja](https://github.com/itajaja) in [#102](https://github.com/apollostack/graphql-tools/pull/102))

--- a/src/schemaGenerator.js
+++ b/src/schemaGenerator.js
@@ -279,9 +279,23 @@ function assertResolveFunctionsPresent(schema, resolverValidationOptions = {}) {
   const {
     requireResolversForArgs = true,
     requireResolversForNonScalar = true,
+    requireResolversForAllFields = false,
   } = resolverValidationOptions;
 
+  if (requireResolversForAllFields && (!requireResolversForArgs || !requireResolversForNonScalar)) {
+    throw new TypeError(
+      'requireResolversForAllFields takes precedence over the more specific assertions. ' +
+      'Please configure either requireResolversForAllFields or requireResolversForArgs / ' +
+      'requireResolversForNonScalar, but not a combination of them.'
+    );
+  }
+
   forEachField(schema, (field, typeName, fieldName) => {
+    // requires a resolve function for *every* field.
+    if (requireResolversForAllFields) {
+      expectResolveFunction(field, typeName, fieldName);
+    }
+
     // requires a resolve function on every field that has arguments
     if (requireResolversForArgs && field.args.length > 0) {
       expectResolveFunction(field, typeName, fieldName);


### PR DESCRIPTION
Asserts that _all_ fields have a valid resolve function.  This effectively disables default resolver behavior.

---

For example, we have a strict set of ACL decorators for our resolvers, and we want developers to be explicit about the access control for each new field they add to our schema

---

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

