### PR TITLE
[Failing Test] Preserve resolvers of types that are waiting on asynchronous operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 coverage
 dist
+*.swp

--- a/test/testMocking.js
+++ b/test/testMocking.js
@@ -786,7 +786,6 @@ describe('Mock', () => {
       RootQuery: {
         user() {
           return new Promise((resolve, reject) => {
-
             // simulates fetching from db
             resolve({
               name: 'User Name',

--- a/test/testMocking.js
+++ b/test/testMocking.js
@@ -767,6 +767,60 @@ describe('Mock', () => {
     });
   });
 
+  it('preserves resolvers when waiting on asynchronous operations', () => {
+    const Schema = buildSchemaFromTypeDefinitions(`
+      type User {
+        name: String
+      }
+
+      type RootQuery {
+        user: User
+      }
+
+      schema {
+        query: RootQuery
+      }
+    `);
+
+    const Resolvers = {
+      RootQuery: {
+        user() {
+          return new Promise((resolve, reject) => {
+
+            // simulates fetching from db
+            resolve({
+              name: 'User Name',
+            });
+          });
+        },
+      },
+    };
+
+    addResolveFunctionsToSchema(Schema, Resolvers);
+
+    addMockFunctionsToSchema({
+      schema: Schema,
+      mocks: {
+        User: () => ({
+          name: 'Mock User Name',
+        }),
+      },
+      preserveResolvers: true,
+    });
+
+    const TestQuery = `
+      {
+        user {
+          name 
+        }
+      }
+    `;
+
+    return graphql(Schema, TestQuery).then((res) => {
+      expect(res.data.user.name).to.equal('User Name');
+    });
+  });
+
   // TODO add a test that checks that even when merging defaults, lists invoke
   // the function for every object, not just once per list.
 


### PR DESCRIPTION
This PR is in reference to this issue:
[https://github.com/apollostack/graphql-tools/issues/105](https://github.com/apollostack/graphql-tools/issues/105)

Mocked types are sent to that types resolvers before RootQuery async operations complete causing resolvers to not be preserved.

It is expected to receive the resolved type from the RootQuery in that types resolvers; however, according to this failing test, a mocked version of that type is received first when the RootQuery returns a Promise and other asynchronous operations like async / await.