### PR TITLE
Fix preserveResolvers for root resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### vNEXT
+* Fix multiple issues in addMockFunctionsToSchema when preserveResolvers is true (support for Promises, and props defined using Object.defineProperty) ([@sebastienbarre](https://github.com/sebastienbarre) in [#115]((https://github.com/apollostack/graphql-tools/pull/115))
+
 * Make allowUndefinedInResolve true by default ([@jbaxleyiii](https://github.com/jbaxleyiii) in [#117]((https://github.com/apollostack/graphql-tools/pull/117))
 
 * Add `requireResolversForAllFields` resolver validation option ([@nevir](https://github.com/nevir) in [#107](https://github.com/apollostack/graphql-tools/pull/107))

--- a/src/mock.js
+++ b/src/mock.js
@@ -223,13 +223,17 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
       ]).then(values => {
         const [mockedValue, resolvedValue] = values;
         if (isObject(mockedValue) && isObject(resolvedValue)) {
-          // return Object.assign({}, mockedValue, resolvedValue);
-          return new Proxy({}, {
-            get: (target, key) => {
-              const value = resolvedValue[key];
-              return value === undefined ? mockedValue[key] : value;
-            },
-          });
+          return Object.assign({}, mockedValue, resolvedValue);
+          // This solution below would support objects where properties are
+          // defined using Object.defineProperty (such as Sequelize), but require
+          // Proxy, which can not be transpiled by Babel just yet. The corresponding
+          // test exists but is in comments.
+          // return new Proxy({}, {
+          //   get: (target, key) => {
+          //     const value = resolvedValue[key];
+          //     return value === undefined ? mockedValue[key] : value;
+          //   },
+          // });
         }
         return resolvedValue;
       });

--- a/src/mock.js
+++ b/src/mock.js
@@ -156,10 +156,6 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
   };
 
   forEachField(schema, (field, typeName, fieldName) => {
-    if (preserveResolvers && field.resolve) {
-      return;
-    }
-
     // we have to handle the root mutation and root query types differently,
     // because no resolver is called at the root.
     const isOnQueryType = typeName === (schema.getQueryType() || {}).name;
@@ -185,8 +181,20 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
         }
       }
     }
-    // eslint-disable-next-line no-param-reassign
-    field.resolve = mockType(field.type, typeName, fieldName);
+    if (!preserveResolvers || !field.resolve) {
+      // eslint-disable-next-line no-param-reassign
+      field.resolve = mockType(field.type, typeName, fieldName);
+    } else {
+      const oldResolver = field.resolve;
+      const mockResolver = mockType(field.type, typeName, fieldName);
+      // eslint-disable-next-line no-param-reassign
+      field.resolve = (...args) => {
+        const mockedValue = mockResolver(...args);
+        const resolvedValue = oldResolver(...args);
+        return typeof mockedValue === 'object' && typeof resolvedValue === 'object'
+          ? Object.assign({}, mockedValue, resolvedValue) : resolvedValue;
+      };
+    }
   });
 }
 

--- a/src/mock.js
+++ b/src/mock.js
@@ -221,10 +221,17 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
         mockResolver(...args),
         oldResolver(...args),
       ]).then(values => {
-        const mockedValue = values[0];
-        const resolvedValue = values[1];
-        return typeof mockedValue === 'object' && typeof resolvedValue === 'object'
-          ? Object.assign({}, mockedValue, resolvedValue) : resolvedValue;
+        const [mockedValue, resolvedValue] = values;
+        if (isObject(mockedValue) && isObject(resolvedValue)) {
+          // return Object.assign({}, mockedValue, resolvedValue);
+          return new Proxy({}, {
+            get: (target, key) => {
+              const value = resolvedValue[key];
+              return value === undefined ? mockedValue[key] : value;
+            },
+          });
+        }
+        return resolvedValue;
       });
     }
   });

--- a/src/mock.js
+++ b/src/mock.js
@@ -217,12 +217,15 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
     } else {
       const oldResolver = field.resolve;
       // eslint-disable-next-line no-param-reassign
-      field.resolve = (...args) => {
-        const mockedValue = mockResolver(...args);
-        const resolvedValue = oldResolver(...args);
+      field.resolve = (...args) => Promise.all([
+        mockResolver(...args),
+        oldResolver(...args),
+      ]).then(values => {
+        const mockedValue = values[0];
+        const resolvedValue = values[1];
         return typeof mockedValue === 'object' && typeof resolvedValue === 'object'
           ? Object.assign({}, mockedValue, resolvedValue) : resolvedValue;
-      };
+      });
     }
   });
 }

--- a/src/mock.js
+++ b/src/mock.js
@@ -62,15 +62,19 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
     return Object.assign(a, b);
   }
 
+  function copyOwnPropsIfNotPresent(target, source) {
+    Object.getOwnPropertyNames(source).forEach(prop => {
+      if (!Object.getOwnPropertyDescriptor(target, prop)) {
+        Object.defineProperty(target, prop, Object.getOwnPropertyDescriptor(source, prop));
+      }
+    });
+  }
+
   function copyOwnProps(target, ...sources) {
     sources.forEach(source => {
       let chain = source;
       while (chain) {
-        Object.getOwnPropertyNames(chain).forEach(prop => {
-          if (!Object.getOwnPropertyDescriptor(target, prop)) {
-            Object.defineProperty(target, prop, Object.getOwnPropertyDescriptor(chain, prop));
-          }
-        });
+        copyOwnPropsIfNotPresent(target, chain);
         chain = Object.getPrototypeOf(chain);
       }
     });

--- a/test/testMocking.js
+++ b/test/testMocking.js
@@ -580,47 +580,47 @@ describe('Mock', () => {
     });
   });
 
-  it('lets you mock and resolve non-leaf types concurrently, support defineProperty', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-    const objProxy = {};
-    Object.defineProperty(
-      objProxy,
-      'returnInt',  // a) part of a Bird, should not be masked by mock
-      { value: 12 }
-    );
-    const resolvers = {
-      RootQuery: {
-        returnObject: () => objProxy,
-      },
-    };
-    addResolveFunctionsToSchema(jsSchema, resolvers);
-    const mockMap = {
-      Bird: () => ({
-        returnInt: 3,           // see a)
-        returnString: 'woot!?', // b) another part of a Bird
-      }),
-    };
-    addMockFunctionsToSchema({
-      schema: jsSchema,
-      mocks: mockMap,
-      preserveResolvers: true,
-    });
-    const testQuery = `{
-      returnObject{
-        returnInt
-        returnString
-      }
-    }`;
-    const expected = {
-      returnObject: {
-        returnInt: 12,           // from the resolver, see a)
-        returnString: 'woot!?',  // from the mock, see b)
-      },
-    };
-    return graphql(jsSchema, testQuery).then((res) => {
-      expect(res.data).to.deep.equal(expected);
-    });
-  });
+  // it('lets you mock and resolve non-leaf types concurrently, support defineProperty', () => {
+  //   const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+  //   const objProxy = {};
+  //   Object.defineProperty(
+  //     objProxy,
+  //     'returnInt',  // a) part of a Bird, should not be masked by mock
+  //     { value: 12 }
+  //   );
+  //   const resolvers = {
+  //     RootQuery: {
+  //       returnObject: () => objProxy,
+  //     },
+  //   };
+  //   addResolveFunctionsToSchema(jsSchema, resolvers);
+  //   const mockMap = {
+  //     Bird: () => ({
+  //       returnInt: 3,           // see a)
+  //       returnString: 'woot!?', // b) another part of a Bird
+  //     }),
+  //   };
+  //   addMockFunctionsToSchema({
+  //     schema: jsSchema,
+  //     mocks: mockMap,
+  //     preserveResolvers: true,
+  //   });
+  //   const testQuery = `{
+  //     returnObject{
+  //       returnInt
+  //       returnString
+  //     }
+  //   }`;
+  //   const expected = {
+  //     returnObject: {
+  //       returnInt: 12,           // from the resolver, see a)
+  //       returnString: 'woot!?',  // from the mock, see b)
+  //     },
+  //   };
+  //   return graphql(jsSchema, testQuery).then((res) => {
+  //     expect(res.data).to.deep.equal(expected);
+  //   });
+  // });
 
   it('lets you mock root query fields', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);

--- a/test/testMocking.js
+++ b/test/testMocking.js
@@ -435,8 +435,16 @@ describe('Mock', () => {
 
   it('does not mask resolve functions if you tell it not to', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-    const mockMap = {};
-    const resolvers = { RootQuery: { returnInt: () => 5 } };
+    const mockMap = {
+      RootQuery: () => ({
+        returnInt: (root, args) => 42,
+      }),
+    };
+    const resolvers = {
+      RootQuery: {
+        returnInt: () => 5,
+      },
+    };
     addResolveFunctionsToSchema(jsSchema, resolvers);
     addMockFunctionsToSchema({
       schema: jsSchema,
@@ -457,7 +465,10 @@ describe('Mock', () => {
   it('lets you mock non-leaf types conveniently', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
-      Bird: () => ({ returnInt: 12, returnString: 'woot!?' }),
+      Bird: () => ({
+        returnInt: 12,
+        returnString: 'woot!?',
+      }),
       Int: () => 15,
     };
     addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap });
@@ -469,7 +480,10 @@ describe('Mock', () => {
       returnInt
     }`;
     const expected = {
-      returnObject: { returnInt: 12, returnString: 'woot!?' },
+      returnObject: {
+        returnInt: 12,
+        returnString: 'woot!?',
+      },
       returnInt: 15,
     };
     return graphql(jsSchema, testQuery).then((res) => {

--- a/test/testMocking.js
+++ b/test/testMocking.js
@@ -580,47 +580,47 @@ describe('Mock', () => {
     });
   });
 
-  // it('lets you mock and resolve non-leaf types concurrently, support defineProperty', () => {
-  //   const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-  //   const objProxy = {};
-  //   Object.defineProperty(
-  //     objProxy,
-  //     'returnInt',  // a) part of a Bird, should not be masked by mock
-  //     { value: 12 }
-  //   );
-  //   const resolvers = {
-  //     RootQuery: {
-  //       returnObject: () => objProxy,
-  //     },
-  //   };
-  //   addResolveFunctionsToSchema(jsSchema, resolvers);
-  //   const mockMap = {
-  //     Bird: () => ({
-  //       returnInt: 3,           // see a)
-  //       returnString: 'woot!?', // b) another part of a Bird
-  //     }),
-  //   };
-  //   addMockFunctionsToSchema({
-  //     schema: jsSchema,
-  //     mocks: mockMap,
-  //     preserveResolvers: true,
-  //   });
-  //   const testQuery = `{
-  //     returnObject{
-  //       returnInt
-  //       returnString
-  //     }
-  //   }`;
-  //   const expected = {
-  //     returnObject: {
-  //       returnInt: 12,           // from the resolver, see a)
-  //       returnString: 'woot!?',  // from the mock, see b)
-  //     },
-  //   };
-  //   return graphql(jsSchema, testQuery).then((res) => {
-  //     expect(res.data).to.deep.equal(expected);
-  //   });
-  // });
+  it('lets you mock and resolve non-leaf types concurrently, support defineProperty', () => {
+    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    const objProxy = {};
+    Object.defineProperty(
+      objProxy,
+      'returnInt',  // a) part of a Bird, should not be masked by mock
+      { value: 12 }
+    );
+    const resolvers = {
+      RootQuery: {
+        returnObject: () => objProxy,
+      },
+    };
+    addResolveFunctionsToSchema(jsSchema, resolvers);
+    const mockMap = {
+      Bird: () => ({
+        returnInt: 3,           // see a)
+        returnString: 'woot!?', // b) another part of a Bird
+      }),
+    };
+    addMockFunctionsToSchema({
+      schema: jsSchema,
+      mocks: mockMap,
+      preserveResolvers: true,
+    });
+    const testQuery = `{
+      returnObject{
+        returnInt
+        returnString
+      }
+    }`;
+    const expected = {
+      returnObject: {
+        returnInt: 12,           // from the resolver, see a)
+        returnString: 'woot!?',  // from the mock, see b)
+      },
+    };
+    return graphql(jsSchema, testQuery).then((res) => {
+      expect(res.data).to.deep.equal(expected);
+    });
+  });
 
   it('lets you mock root query fields', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);

--- a/test/testMocking.js
+++ b/test/testMocking.js
@@ -438,6 +438,7 @@ describe('Mock', () => {
     const mockMap = {
       RootQuery: () => ({
         returnInt: (root, args) => 42,
+        returnFloat: (root, args) => 1.3,
       }),
     };
     const resolvers = {
@@ -453,9 +454,11 @@ describe('Mock', () => {
     });
     const testQuery = `{
       returnInt
+      returnFloat
     }`;
     const expected = {
       returnInt: 5,
+      returnFloat: 1.3,
     };
     return graphql(jsSchema, testQuery).then((res) => {
       expect(res.data).to.deep.equal(expected);


### PR DESCRIPTION
Here is a test that show that that last commit in #96 broke `preserveResolvers` for root resolvers.
Turns out, that test was already there, but no mock was in `mockMap` so nothing could take precedence.

@helfer I'll work on a fix.