### PR TITLE
Bugfix for resolving & mocking, when resolve is wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### vNEXT
 * Added embedded Typescript definitions ([@DxCx](https://github.com/DxCx) in [#120](https://github.com/apollostack/graphql-tools/pull/120))
 
+* Fix issue in addMockFunctionsToSchema when preserveResolvers is true and connector/logger is used. ([@DxCx](https://github.com/DxCx) in [#121](https://github.com/apollostack/graphql-tools/pull/121))
+
 * Fix multiple issues in addMockFunctionsToSchema when preserveResolvers is true (support for Promises, and props defined using Object.defineProperty) ([@sebastienbarre](https://github.com/sebastienbarre) in [#115](https://github.com/apollostack/graphql-tools/pull/115))
 
 * Make allowUndefinedInResolve true by default ([@jbaxleyiii](https://github.com/jbaxleyiii) in [#117](https://github.com/apollostack/graphql-tools/pull/117))

--- a/src/mock.js
+++ b/src/mock.js
@@ -246,7 +246,7 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
           // the non-enumerable ones and defined using Object.defineProperty
           return copyOwnProps({}, resolvedValue, mockedValue);
         }
-        return resolvedValue;
+        return (undefined !== resolvedValue) ? resolvedValue : mockedValue;
       });
     }
   });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

I've noted a bug with @sebastienbarre 's new logic to merge resolvers & mocks ([#115](https://github.com/apollostack/graphql-tools/pull/115))
Basiclly, if there is a connector or a logger (or any other wrapper, hidden as a resolve function),
the original resolve function value will be undefined (as it's not provided)
and then an undefined will be returned, instead of the proper mocked value.

TODO:

- [x] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

