### PR TITLE
Standard version supprt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,11 +3,53 @@
 
   Please look at the following checklist to ensure that your PR
   can be accepted quickly:
+
+  Commmits Formatting:
+  ---------------------
+  A commit message consists of a **header**, **body** and **footer**.  The header has a **type**, **scope** and **subject**:
+  <type>(<scope>): <subject>
+  <BLANK LINE>
+  <body>
+  <BLANK LINE>
+  <footer>
+
+  ## Header
+
+  The **header** is mandatory and the **scope** of the header is optional.
+
+  If the type is `feat`, `fix` or `perf`, it will appear in the changelog. 
+  Suggested prefixes are `docs`, `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
+  However if there is any [BREAKING CHANGE](#footer), the commit will always appear in the changelog.
+
+  The subject contains succinct description of the change:
+
+  * use the imperative, present tense: "change" not "changed" nor "changes"
+  * don't capitalize first letter
+  * no dot (.) at the end
+
+  ## Footer
+
+  The footer should contain any information about **Breaking Changes** and is also the place to
+  reference GitHub issues that this commit **Closes**.
+
+  **Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.
+
+  For Example:
+  * feat(autopublish): add 'autopublishMutationResults' function
+
+    when enabled, after each mutation, the result will be published using the mutation name.
+
+  * fix(mock): error handling when preserveResolvers = true
+
+    Closes #149
+
+  * chore: remove mockServer
+
+    BREAKING CHANGE: remove mockServer which got deprectaed on version 0.4.0
 -->
 
 TODO:
 
-- [ ] Commits are formatted for [Standard Version](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md)
 - [ ] Make sure all of the significant new logic is covered by tests
 - [ ] Rebase your changes on master so that they can be merged easily
 - [ ] Make sure all tests and linter rules pass

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 
 TODO:
 
-- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
+- [ ] Commits are formatted for [Standard Version](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md)
 - [ ] Make sure all of the significant new logic is covered by tests
 - [ ] Rebase your changes on master so that they can be merged easily
 - [ ] Make sure all tests and linter rules pass

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,23 @@
 <!--
   Thanks for filing a pull request on Apollo Client!
 
-  Please look at the following checklist to ensure that your PR
-  can be accepted quickly:
+  We are using standard-version because it makes it easier to keep track of relevant changes when we publish releases, and because it removes the need for a CHANGELOG.md file, which often leads to merge conflicts in pull requests.
+  (More info about the formating below)
+  
+  If you're not sure how exactly to format the commit message, don't worry about it. Just make the PR, and we'll fix it for you when we merge it.
 
-  Commmits Formatting:
+  Finally, please look at the following checklist to ensure that your PR
+  can be accepted quickly:
+-->
+
+TODO:
+
+- [ ] Make sure all of the significant new logic is covered by tests
+- [ ] Rebase your changes on master so that they can be merged easily
+- [ ] Make sure all tests and linter rules pass
+
+<!--
+Commmits Formatting: (https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md)
   ---------------------
   A commit message consists of a **header**, **body** and **footer**.  The header has a **type**, **scope** and **subject**:
   <type>(<scope>): <subject>
@@ -47,9 +60,3 @@
 
     BREAKING CHANGE: remove mockServer which got deprectaed on version 0.4.0
 -->
-
-TODO:
-
-- [ ] Make sure all of the significant new logic is covered by tests
-- [ ] Rebase your changes on master so that they can be merged easily
-- [ ] Make sure all tests and linter rules pass

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,24 @@
 <!--
   Thanks for filing a pull request on Apollo Client!
 
-  We are using standard-version because it makes it easier to keep track of relevant changes when we publish releases, and because it removes the need for a CHANGELOG.md file, which often leads to merge conflicts in pull requests.
-  (More info about the formating below)
-  
-  If you're not sure how exactly to format the commit message, don't worry about it. Just make the PR, and we'll fix it for you when we merge it.
-
-  Finally, please look at the following checklist to ensure that your PR
+  Please look at the following checklist to ensure that your PR
   can be accepted quickly:
 -->
 
 TODO:
 
+- [ ] Commit messages are formatted in a standard-version friendly way
 - [ ] Make sure all of the significant new logic is covered by tests
 - [ ] Rebase your changes on master so that they can be merged easily
 - [ ] Make sure all tests and linter rules pass
 
 <!--
+ We are using standard-version because it makes it easier to keep track of relevant changes when we publish releases, and because it removes the need for a CHANGELOG.md file, which often leads to merge conflicts in pull requests.
+  (More info about the formating below)
+  
+  If you're not sure how exactly to format a commit message, don't worry about it. Just make the PR, and we'll fix it for you when we merge it. We'd much rather have your PR than not have it!
+
+
 Commmits Formatting: (https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md)
   ---------------------
   A commit message consists of a **header**, **body** and **footer**.  The header has a **type**, **scope** and **subject**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# Changelog
-
-### vNEXT
- * Bugfix for error handling on preserveResolvers ([#149](https://github.com/apollostack/graphql-tools/issues/149)). ([@DxCx](https://github.com/DxCx) in [#151](https://github.com/apollostack/graphql-tools/pull/151))
- 
 ### v0.7.2
  * Eliminated babel and moved to native ES5 compilation. ([@DxCx](https://github.com/DxCx) in [#147](https://github.com/apollostack/graphql-tools/pull/147))
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/apollostack/graphql-tools.svg?branch=master)](https://travis-ci.org/apollostack/graphql-tools)
 [![Coverage Status](https://coveralls.io/repos/github/apollostack/graphql-tools/badge.svg?branch=master)](https://coveralls.io/github/apollostack/graphql-tools?branch=master)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://www.apollostack.com/#slack)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js",
     "coverage": "istanbul cover _mocha -- --reporter dot --full-trace ./dist/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.json --type lcovonly --output coverage/lcov.info",
-    "prepublish": "npm run compile"
+    "prepublish": "npm run compile",
+    "prerelease": "npm test",
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -77,6 +79,7 @@
     "request": "^2.72.0",
     "request-promise": "^4.1.0",
     "source-map-support": "^0.4.2",
+    "standard-version": "^2.4.0",
     "supertest": "^2.0.0",
     "supertest-as-promised": "^4.0.0",
     "tslint": "^3.15.1",


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Hi,

I've added a new command, npm run release which runs standard version for automatic semver + changelog.

TODO:

- [ ] Update CHANGELOG.md with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
