### PR TITLE
chore(package): copy graphql-subscriptions to peerDepenecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "node-uuid": "^1.4.7"
   },
   "peerDependencies": {
-    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0"
+    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0",
+    "graphql-subscriptions": "^0.2.0"
   },
   "optionalDependencies": {
     "typed-graphql": "^1.0.2"


### PR DESCRIPTION
as autopublish feature exports a symbol from graphql-subscriptions package,
it should be either move to dependencies or copied to peerDependencies.

TODO:

- [X] Commit messages are formatted in a standard-version friendly way
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass