### PR TITLE
addSchemaLevelResolveFunction resolves once per operation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 * ...
+* `addSchemaLevelResolveFunction` resolves once per operation type and not once globally. [#220](https://github.com/apollostack/graphql-tools/pull/220)
 
 ### v0.8.3
 

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -250,7 +250,13 @@ function addSchemaLevelResolveFunction(schema: GraphQLSchema, fn: GraphQLFieldRe
     const rootResolveFn = runAtMostOncePerRequest(fn);
     const fields = type.getFields();
     Object.keys(fields).forEach((fieldName) => {
-      fields[fieldName].resolve = wrapResolver(fields[fieldName].resolve, rootResolveFn);
+      // XXX if the type is a subscription, a same query AST will be ran multiple times so we
+      // deactivate here the runOnce if it's a subscription. This may not be optimal though...
+      if (type === schema.getSubscriptionType()) {
+        fields[fieldName].resolve = wrapResolver(fields[fieldName].resolve, fn);
+      } else {
+        fields[fieldName].resolve = wrapResolver(fields[fieldName].resolve, rootResolveFn);
+      }
     });
   });
 }

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -244,10 +244,10 @@ function addSchemaLevelResolveFunction(schema: GraphQLSchema, fn: GraphQLFieldRe
     schema.getMutationType(),
     schema.getSubscriptionType(),
   ]).filter(x => !!x);
-  // XXX this should run at most once per request to simulate a true root resolver
-  // for graphql-js this is an approximation that works with queries but not mutations
-  const rootResolveFn = runAtMostOncePerRequest(fn);
   rootTypes.forEach((type) => {
+    // XXX this should run at most once per request to simulate a true root resolver
+    // for graphql-js this is an approximation that works with queries but not mutations
+    const rootResolveFn = runAtMostOncePerRequest(fn);
     const fields = type.getFields();
     Object.keys(fields).forEach((fieldName) => {
       fields[fieldName].resolve = wrapResolver(fields[fieldName].resolve, rootResolveFn);

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -242,7 +242,6 @@ function addSchemaLevelResolveFunction(schema: GraphQLSchema, fn: GraphQLFieldRe
   const rootTypes = ([
     schema.getQueryType(),
     schema.getMutationType(),
-    schema.getSubscriptionType(),
   ]).filter(x => !!x);
   rootTypes.forEach((type) => {
     // XXX this should run at most once per request to simulate a true root resolver

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -242,6 +242,7 @@ function addSchemaLevelResolveFunction(schema: GraphQLSchema, fn: GraphQLFieldRe
   const rootTypes = ([
     schema.getQueryType(),
     schema.getMutationType(),
+    schema.getSubscriptionType(),
   ]).filter(x => !!x);
   rootTypes.forEach((type) => {
     // XXX this should run at most once per request to simulate a true root resolver

--- a/src/test/testResolution.ts
+++ b/src/test/testResolution.ts
@@ -1,0 +1,134 @@
+import { assert } from 'chai';
+import {
+  makeExecutableSchema,
+  addSchemaLevelResolveFunction,
+} from '..';
+import { graphql } from 'graphql';
+import { PubSub, SubscriptionManager } from 'graphql-subscriptions';
+
+describe('Resolve', () => {
+  describe('addSchemaLevelResolveFunction', () => {
+    const pubsub = new PubSub();
+    const typeDefs = `
+      type RootQuery {
+        printRoot: String!
+        printRootAgain: String!
+      }
+
+      type RootMutation {
+        printRoot: String!
+      }
+
+      type RootSubscription {
+        printRoot: String!
+      }
+
+      schema {
+        query: RootQuery
+        mutation: RootMutation
+        subscription: RootSubscription
+      }
+    `;
+    const printRoot = (root: any) => root.toString();
+    const subscriptionRoot = 'subscriptionRoot';
+    const resolvers = {
+      RootQuery: {
+        printRoot,
+        printRootAgain: printRoot,
+      },
+      RootMutation: {
+        printRoot: (root: any) => {
+          pubsub.publish('printRoot', subscriptionRoot);
+          return printRoot(root);
+        },
+      },
+      RootSubscription: {
+        printRoot,
+      },
+    };
+    const schema = makeExecutableSchema({typeDefs, resolvers});
+    let schemaLevelResolveFunctionCalls = 0;
+    addSchemaLevelResolveFunction(schema, root => {
+      schemaLevelResolveFunctionCalls += 1;
+      return root;
+    });
+    const subcriptionManager = new SubscriptionManager({
+      schema,
+      pubsub,
+      setupFunctions: {
+        printRoot: () => ({
+          printRoot: {
+            filter: () => true,
+          },
+        }),
+      },
+    });
+
+    it('should run the schema level resolver once in a same query', () => {
+      schemaLevelResolveFunctionCalls = 0;
+      const root = 'queryRoot';
+      return graphql(schema, `
+        query TestOnce {
+          printRoot
+          printRootAgain
+        }
+      `, root).then(({data}) => {
+        assert.deepEqual(data, {
+          printRoot: root,
+          printRootAgain: root,
+        });
+        assert.equal(schemaLevelResolveFunctionCalls, 1);
+      });
+    });
+
+    it('should isolate roots from the different operation types', () => {
+      schemaLevelResolveFunctionCalls = 0;
+      const queryRoot = 'queryRoot';
+      const mutationRoot = 'mutationRoot';
+      return graphql(schema, `
+        query TestQuery {
+          printRoot
+        }
+      `, queryRoot)
+      .then(({data}) => {
+        assert.deepEqual(data, {
+          printRoot: queryRoot,
+        });
+        assert.equal(schemaLevelResolveFunctionCalls, 1);
+        const subscribePromise = new Promise((resolve, reject) =>
+          subcriptionManager.subscribe({
+            query: `
+              subscription TestSubscription {
+                printRoot
+              }
+            `,
+            operationName: 'TestSubscription',
+            callback: (err: any, subsData: any) => {
+              if (err) {
+                return reject(err);
+              }
+              resolve(subsData);
+            },
+          })
+        );
+        return Promise.all([
+          graphql(schema, `
+            mutation TestMutation {
+              printRoot
+            }
+          `, mutationRoot),
+          subscribePromise,
+        ]);
+      })
+      .then(([{data: mutationData}, {data: subsData}]) => {
+        assert.deepEqual(mutationData, {
+          printRoot: mutationRoot,
+        });
+        assert.deepEqual(subsData, {
+          printRoot: subscriptionRoot,
+        });
+        assert.equal(schemaLevelResolveFunctionCalls, 3);
+      });
+    });
+  });
+});

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -4,3 +4,4 @@ import './testSchemaGenerator';
 import './testLogger';
 import './testMocking';
 import './testAutopublish';
+import './testResolution';


### PR DESCRIPTION
Basically, we isolate here the "run once" between possible operations instead of having them for all of the operations. Sometimes, a race condition could indeed mess with the root value of a subscription. We ensure this does not happen here.

This should fix #218