### PR TITLE
use function reference instead of string for concatenateTypeDefs

### DIFF
--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -110,16 +110,17 @@ function makeExecutableSchema({
   return jsSchema;
 }
 
-function concatenateTypeDefs(typeDefinitionsAry: ITypedef[], functionsCalled = {}): string {
+function concatenateTypeDefs(typeDefinitionsAry: ITypedef[], calledFunctionRefs = [] as any ): string {
   let resolvedTypeDefinitions: string[] = [];
   typeDefinitionsAry.forEach((typeDef: ITypedef) => {
     if (typeof typeDef === 'function') {
-      if (!(typeDef as any in functionsCalled)) {
-        functionsCalled[typeDef as any] = 1;
+      if (calledFunctionRefs.indexOf(typeDef) === -1) {
+        calledFunctionRefs.push(typeDef);
         resolvedTypeDefinitions = resolvedTypeDefinitions.concat(
-          concatenateTypeDefs(typeDef(), functionsCalled)
+          concatenateTypeDefs(typeDef(), calledFunctionRefs)
         );
       }
+
     } else if (typeof typeDef === 'string') {
       resolvedTypeDefinitions.push(typeDef.trim());
     } else {

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -517,4 +517,5 @@ export {
   buildSchemaFromTypeDefinitions,
   addSchemaLevelResolveFunction,
   attachConnectorsToContext,
+  concatenateTypeDefs,
 };


### PR DESCRIPTION
hey @stubailo - i spend some hours traveling through my code and searching for an issue we found in our project after we started to export our typeDefs inside of objects that get combined with a function. The problem seems to be with the way the tools are checking how to include a 

Our objects are structured like this: 

```
import TypeB from './TypeB';

const TypeA = {
    typeDefs: `
        type TypeA {
            name: String!
            field: TypeB
        }
        `,
    resolvers: {
        TypeA: {
            name: () => null,
            field: () => null,
        },
    },
};

export default combineSchemaDependencies(TypeA, TypeB);
```

`typeDefs` can be a function returning an array or a string like you expect for the typeDefinitions passed into `makeExecutableSchema`.  As soon as i export my objects via my function there are no typeDefinitions in the result. The reason for that is that i combine the types like this:

```
function combineSchemaDependencies(...args) {
    return {
        typeDefs: () => args.map(a => a.typeDefs),
        resolvers: args.reduce((result, obj) => Object.assign(result, obj.resolvers), {}),
    };
}
```

What i debugged is that the `concatenateTypeDefs` function decides if a function that is inside the array will be resolved or not. It stores the functions that have been called as an key inside an object. That causes the function to  become a string. Something like that `() => [TypeA, TypeB]` - In my case we have a function generating the function that will return the function that returns the array 💃 . That causes that the string that will be saved into the array is ` () => args.map(a => a.typeDefs)` - and then its the same for every export with the combine function and none of my types gets imported into the schema.

So to allow circular dependencies while not having to rely on a string of the function that is checked i would suggest to simply save the reference of the function into an array and then decide depending on the reference. This works for circular dependencies as the imports are only done once and therefore the reference should stay the same. I have tried to create a test for my case but TypeScript drove me crazy as i am not so familiar with it.

Let me know if you have some thoughts on this or any feedback.
